### PR TITLE
Remove mocks and add OpenAI endpoints

### DIFF
--- a/backend/agents/social_media_agent.py
+++ b/backend/agents/social_media_agent.py
@@ -424,30 +424,17 @@ class SocialMediaAgent:
             engagement_data = []
             
             for post in posts_to_monitor:
-                # Simulate fetching engagement data from platform
-                # In real implementation, this would call platform APIs
-                
-                # Generate mock engagement based on post age and content
-                hours_since_publish = (datetime.now() - (post.published_time or datetime.now())).total_seconds() / 3600
-                base_engagement = max(1, int(50 - hours_since_publish))  # Engagement decreases over time
-                
+                # Real implementations should query the respective platform APIs
+                # for engagement metrics. Here we simply return stored stats.
+                stats = post.engagement_stats or {}
                 engagement = {
                     "post_id": post.id,
                     "platform": post.platform.value,
-                    "likes": base_engagement + int(len(post.content) / 10),
-                    "comments": max(0, int(base_engagement / 5)),
-                    "shares": max(0, int(base_engagement / 10)),
-                    "clicks": max(0, int(base_engagement / 3)),
-                    "impressions": base_engagement * 20,
-                    "reach": base_engagement * 15,
-                    "engagement_rate": min(5.0, base_engagement / 10),
-                    "last_updated": datetime.now().isoformat()
+                    **stats,
+                    "last_updated": datetime.now().isoformat(),
                 }
-                
-                # Update post engagement stats
-                post.engagement_stats = engagement
+
                 self.posts_store[post.id] = post
-                
                 engagement_data.append(engagement)
             
             return {

--- a/backend/routes/brand.py
+++ b/backend/routes/brand.py
@@ -2,18 +2,50 @@ from fastapi import APIRouter, UploadFile, File, HTTPException
 import openai
 import os
 
+DOCUMENTS_DIR = "brand_documents"
+os.makedirs(DOCUMENTS_DIR, exist_ok=True)
+
 router = APIRouter(prefix="/api/brand", tags=["brand"])
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 @router.post("/documents")
 async def upload_document(file: UploadFile = File(...)):
-   return {"message": "Brand Ambassador endpoint working", "filename": file.filename}
+    """Save uploaded brand document to disk."""
+    try:
+        contents = await file.read()
+        dest = os.path.join(DOCUMENTS_DIR, file.filename)
+        with open(dest, "wb") as f:
+            f.write(contents)
+        return {"filename": file.filename}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/documents")
 async def get_documents():
-   return []
+    """List uploaded brand documents."""
+    try:
+        return {"files": os.listdir(DOCUMENTS_DIR)}
+    except Exception:
+        return {"files": []}
 
 @router.post("/chat")
 async def chat_with_brand(message: dict):
-   return {"response": "Brand Ambassador is working! Your message: " + message.get("message", "")}
+    """Interact with the brand ambassador powered by OpenAI."""
+    prompt = message.get("message")
+    if not prompt:
+        raise HTTPException(status_code=400, detail="Message is required")
+    if not openai.api_key:
+        raise HTTPException(status_code=500, detail="OpenAI API key not configured")
+    try:
+        chat = await openai.ChatCompletion.acreate(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": "You are a helpful brand ambassador assistant."},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.7,
+        )
+        return {"response": chat.choices[0].message.content.strip()}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/routes/content.py
+++ b/backend/routes/content.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from typing import Dict, Any, List, Optional
 import uuid
 from datetime import datetime
@@ -44,21 +44,7 @@ async def generate_content(brief: ContentBriefRequest, token: str = Depends(veri
             )
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            # Mock content generation
-            mock_content = {
-                "id": str(uuid.uuid4()),
-                "title": brief.title,
-                "content": f"AI-generated {brief.content_type} content for {brief.target_audience}. This content focuses on {', '.join(brief.key_messages[:3])} with a {brief.tone} tone.",
-                "html_content": f"<h2>{brief.title}</h2><p>AI-generated {brief.content_type} content for <strong>{brief.target_audience}</strong>.</p><p>This content focuses on {', '.join(brief.key_messages[:3])} with a {brief.tone} tone.</p>",
-                "cta": brief.cta or "Take Action Now",
-                "seo_score": 85,
-                "readability_score": 92,
-                "engagement_prediction": 0.78,
-                "tags": brief.keywords[:5] if brief.keywords else ["marketing", "growth", "engagement"],
-                "status": "generated",
-                "created_at": datetime.now().isoformat() + "Z"
-            }
-            return APIResponse(success=True, data=mock_content)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error generating content: {e}")
         return APIResponse(success=False, error=str(e))
@@ -76,16 +62,7 @@ async def create_content(content_data: Dict[str, Any], token: str = Depends(veri
             )
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            new_content = {
-                "id": str(uuid.uuid4()),
-                "title": content_data.get("title", "Generated Content"),
-                "content": "This is AI-generated content based on your prompt.",
-                "type": content_data.get("type", "blog_post"),
-                "status": "draft",
-                "created_at": datetime.now().isoformat() + "Z",
-                **content_data
-            }
-            return APIResponse(success=True, data=new_content)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error creating content: {e}")
         return APIResponse(success=False, error=str(e))
@@ -98,25 +75,7 @@ async def get_content_library(content_type: str = None, platform: str = None, to
             result = await agent_manager.content_agent.get_content_library(content_type, platform)
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            mock_content = [
-                {
-                    "id": str(uuid.uuid4()),
-                    "title": "10 Marketing Tips for 2024",
-                    "type": "blog_post",
-                    "status": "published",
-                    "engagement": 245,
-                    "created_at": "2024-01-10T10:00:00Z"
-                },
-                {
-                    "id": str(uuid.uuid4()),
-                    "title": "Product Launch Email Template",
-                    "type": "email_template",
-                    "status": "draft",
-                    "engagement": 0,
-                    "created_at": "2024-01-12T15:30:00Z"
-                }
-            ]
-            return APIResponse(success=True, data=mock_content)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error getting content library: {e}")
         return APIResponse(success=False, error=str(e))

--- a/backend/routes/email.py
+++ b/backend/routes/email.py
@@ -24,54 +24,7 @@ async def get_email_real_time_metrics(
             result = await agent_manager.email_agent.get_campaign_metrics(campaign_id, time_range)
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            # Mock data that matches EmailMetricsData interface
-            mock_metrics = {
-                "total_sent": 1250,
-                "total_delivered": 1200,
-                "total_opened": 480,
-                "total_clicked": 96,
-                "total_bounced": 50,
-                "total_unsubscribed": 12,
-                "delivery_rate": 96.0,
-                "open_rate": 40.0,
-                "click_rate": 8.0,
-                "bounce_rate": 4.0,
-                "unsubscribe_rate": 1.0,
-                "engagement_score": 85,
-                "trends": [
-                    {
-                        "timestamp": (datetime.now() - timedelta(hours=2)).isoformat(),
-                        "opens": 120,
-                        "clicks": 24
-                    },
-                    {
-                        "timestamp": (datetime.now() - timedelta(hours=1)).isoformat(),
-                        "opens": 180,
-                        "clicks": 36
-                    },
-                    {
-                        "timestamp": datetime.now().isoformat(),
-                        "opens": 180,
-                        "clicks": 36
-                    }
-                ],
-                "insights": [
-                    {
-                        "type": "success",
-                        "metric": "open_rate",
-                        "message": "Open rate is performing above average",
-                        "recommendation": "Continue with current subject line strategy"
-                    },
-                    {
-                        "type": "warning",
-                        "metric": "click_rate",
-                        "message": "Click-through rate could be improved",
-                        "recommendation": "Consider A/B testing your call-to-action buttons"
-                    }
-                ],
-                "last_updated": datetime.now().isoformat()
-            }
-            return APIResponse(success=True, data=mock_metrics)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error getting email metrics for campaign {campaign_id}: {e}")
         return APIResponse(success=False, error=str(e))
@@ -90,13 +43,7 @@ async def create_email_campaign(campaign_data: Dict[str, Any], token: str = Depe
             )
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            new_campaign = {
-                "id": str(uuid.uuid4()),
-                "created_at": datetime.now().isoformat(),
-                "updated_at": datetime.now().isoformat(),
-                **campaign_data
-            }
-            return APIResponse(success=True, data=new_campaign)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error creating email campaign: {e}")
         return APIResponse(success=False, error=str(e))
@@ -113,16 +60,7 @@ async def generate_email_content(content_data: Dict[str, Any], token: str = Depe
             )
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            # Mock AI generated content
-            mock_content = {
-                "content": "🚀 Exciting News! Our latest product launch is here and we're thrilled to share it with you. Discover innovative features that will transform your workflow and boost productivity by 40%. Limited time offer - get 20% off your first month!",
-                "subject_lines": [
-                    {"text": "🚀 Revolutionary Product Launch - 40% Productivity Boost!", "score": 94},
-                    {"text": "Transform Your Workflow Today - Limited Time Offer", "score": 87},
-                    {"text": "Exclusive Access: Game-Changing Features Inside", "score": 91}
-                ]
-            }
-            return APIResponse(success=True, data=mock_content)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error generating email content: {e}")
         return APIResponse(success=False, error=str(e))
@@ -137,15 +75,7 @@ async def generate_ab_variants(variant_data: Dict[str, Any], token: str = Depend
             )
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            # Mock A/B variants
-            mock_variants = {
-                "variants": [
-                    {"text": "Boost Your Success - Try Our New Features!", "score": 88},
-                    {"text": "Unlock Premium Features - Special Launch Pricing", "score": 92},
-                    {"text": "Don't Miss Out - Revolutionary Tools Inside", "score": 85}
-                ]
-            }
-            return APIResponse(success=True, data=mock_variants)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error generating A/B variants: {e}")
         return APIResponse(success=False, error=str(e))
@@ -161,13 +91,7 @@ async def optimize_send_time(timing_data: Dict[str, Any], token: str = Depends(v
             )
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            # Mock optimal timing
-            mock_timing = {
-                "optimal_time": "Tuesday 10:30 AM",
-                "improvement": 23,
-                "confidence": 87
-            }
-            return APIResponse(success=True, data=mock_timing)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error optimizing send time: {e}")
         return APIResponse(success=False, error=str(e))

--- a/backend/routes/integrations.py
+++ b/backend/routes/integrations.py
@@ -18,30 +18,7 @@ router = APIRouter(prefix="/api/integrations", tags=["integrations"])
 async def get_webhooks(token: str = Depends(verify_token)):
     """Get all webhooks for the authenticated user"""
     try:
-        # Mock webhook data for now - will be replaced with Supabase queries
-        mock_webhooks = [
-            {
-                "id": str(uuid.uuid4()),
-                "name": "Campaign Completed",
-                "url": "https://api.company.com/webhooks/campaign-complete",
-                "events": ["campaign.completed", "campaign.paused"],
-                "is_active": True,
-                "last_triggered_at": datetime.now().isoformat(),
-                "last_response_code": 200,
-                "created_at": datetime.now().isoformat()
-            },
-            {
-                "id": str(uuid.uuid4()),
-                "name": "Lead Generated",
-                "url": "https://api.company.com/webhooks/new-lead",
-                "events": ["lead.created", "lead.qualified"],
-                "is_active": True,
-                "last_triggered_at": datetime.now().isoformat(),
-                "last_response_code": 200,
-                "created_at": datetime.now().isoformat()
-            }
-        ]
-        return APIResponse(success=True, data=mock_webhooks)
+        raise HTTPException(status_code=503, detail="Webhook storage not configured")
     except Exception as e:
         logger.error(f"Error fetching webhooks: {e}")
         return APIResponse(success=False, error=str(e))
@@ -100,16 +77,7 @@ async def connect_buffer(connection_data: Dict[str, Any], token: str = Depends(v
             return APIResponse(success=False, error="API key is required")
         
         # Mock connection validation
-        connection_result = {
-            "service": "buffer",
-            "status": "connected",
-            "connected_at": datetime.now().isoformat(),
-            "account_info": {
-                "username": "example_user",
-                "plan": "pro"
-            }
-        }
-        return APIResponse(success=True, data=connection_result)
+        raise HTTPException(status_code=501, detail="Buffer integration not implemented")
     except Exception as e:
         logger.error(f"Error connecting to Buffer: {e}")
         return APIResponse(success=False, error=str(e))
@@ -122,16 +90,7 @@ async def connect_hootsuite(connection_data: Dict[str, Any], token: str = Depend
         if not api_key:
             return APIResponse(success=False, error="API key is required")
         
-        connection_result = {
-            "service": "hootsuite",
-            "status": "connected",
-            "connected_at": datetime.now().isoformat(),
-            "account_info": {
-                "organization": "Example Corp",
-                "plan": "enterprise"
-            }
-        }
-        return APIResponse(success=True, data=connection_result)
+        raise HTTPException(status_code=501, detail="Hootsuite integration not implemented")
     except Exception as e:
         logger.error(f"Error connecting to Hootsuite: {e}")
         return APIResponse(success=False, error=str(e))
@@ -144,16 +103,7 @@ async def connect_later(connection_data: Dict[str, Any], token: str = Depends(ve
         if not api_key:
             return APIResponse(success=False, error="API key is required")
         
-        connection_result = {
-            "service": "later",
-            "status": "connected",
-            "connected_at": datetime.now().isoformat(),
-            "account_info": {
-                "username": "example_later",
-                "plan": "premium"
-            }
-        }
-        return APIResponse(success=True, data=connection_result)
+        raise HTTPException(status_code=501, detail="Later integration not implemented")
     except Exception as e:
         logger.error(f"Error connecting to Later: {e}")
         return APIResponse(success=False, error=str(e))
@@ -166,16 +116,7 @@ async def connect_sprout_social(connection_data: Dict[str, Any], token: str = De
         if not api_key:
             return APIResponse(success=False, error="API key is required")
         
-        connection_result = {
-            "service": "sprout_social",
-            "status": "connected",
-            "connected_at": datetime.now().isoformat(),
-            "account_info": {
-                "organization": "Example Enterprise",
-                "plan": "enterprise"
-            }
-        }
-        return APIResponse(success=True, data=connection_result)
+        raise HTTPException(status_code=501, detail="Sprout Social integration not implemented")
     except Exception as e:
         logger.error(f"Error connecting to Sprout Social: {e}")
         return APIResponse(success=False, error=str(e))
@@ -188,16 +129,7 @@ async def connect_video_publisher(connection_data: Dict[str, Any], token: str = 
         if not api_key:
             return APIResponse(success=False, error="API key is required")
         
-        connection_result = {
-            "service": "video_publisher",
-            "status": "connected",
-            "connected_at": datetime.now().isoformat(),
-            "account_info": {
-                "credits_remaining": 500,
-                "plan": "professional"
-            }
-        }
-        return APIResponse(success=True, data=connection_result)
+        raise HTTPException(status_code=501, detail="Video publisher integration not implemented")
     except Exception as e:
         logger.error(f"Error connecting to Video Publisher: {e}")
         return APIResponse(success=False, error=str(e))
@@ -207,45 +139,7 @@ async def connect_video_publisher(connection_data: Dict[str, Any], token: str = 
 async def get_connections(token: str = Depends(verify_token)):
     """Get all integration connections"""
     try:
-        mock_connections = [
-            {
-                "service_name": "google_analytics",
-                "connection_status": "connected",
-                "last_sync_at": datetime.now().isoformat(),
-                "sync_status": "success"
-            },
-            {
-                "service_name": "mailchimp",
-                "connection_status": "connected",
-                "last_sync_at": datetime.now().isoformat(),
-                "sync_status": "success"
-            },
-            {
-                "service_name": "slack",
-                "connection_status": "disconnected",
-                "last_sync_at": None,
-                "sync_status": "idle"
-            },
-            {
-                "service_name": "shopify",
-                "connection_status": "connected",
-                "last_sync_at": datetime.now().isoformat(),
-                "sync_status": "success"
-            },
-            {
-                "service_name": "stripe",
-                "connection_status": "connected",
-                "last_sync_at": datetime.now().isoformat(),
-                "sync_status": "success"
-            },
-            {
-                "service_name": "hubspot",
-                "connection_status": "disconnected",
-                "last_sync_at": None,
-                "sync_status": "idle"
-            }
-        ]
-        return APIResponse(success=True, data=mock_connections)
+        raise HTTPException(status_code=503, detail="Connection listing not implemented")
     except Exception as e:
         logger.error(f"Error fetching connections: {e}")
         return APIResponse(success=False, error=str(e))
@@ -258,13 +152,7 @@ async def connect_service(service: str, connection_data: Dict[str, Any], token: 
         if not api_key:
             return APIResponse(success=False, error="API key is required")
         
-        connection_result = {
-            "service": service,
-            "status": "connected",
-            "connected_at": datetime.now().isoformat(),
-            "message": f"Successfully connected to {service}"
-        }
-        return APIResponse(success=True, data=connection_result)
+        raise HTTPException(status_code=501, detail=f"Integration {service} not implemented")
     except Exception as e:
         logger.error(f"Error connecting to {service}: {e}")
         return APIResponse(success=False, error=str(e))
@@ -273,13 +161,7 @@ async def connect_service(service: str, connection_data: Dict[str, Any], token: 
 async def sync_service(service: str, token: str = Depends(verify_token)):
     """Trigger data sync for a service"""
     try:
-        sync_result = {
-            "service": service,
-            "sync_status": "success",
-            "synced_at": datetime.now().isoformat(),
-            "records_synced": 125
-        }
-        return APIResponse(success=True, data=sync_result)
+        raise HTTPException(status_code=501, detail=f"Sync for {service} not implemented")
     except Exception as e:
         logger.error(f"Error syncing {service}: {e}")
         return APIResponse(success=False, error=str(e))
@@ -288,12 +170,7 @@ async def sync_service(service: str, token: str = Depends(verify_token)):
 async def disconnect_service(service: str, token: str = Depends(verify_token)):
     """Disconnect from a service"""
     try:
-        disconnect_result = {
-            "service": service,
-            "status": "disconnected",
-            "disconnected_at": datetime.now().isoformat()
-        }
-        return APIResponse(success=True, data=disconnect_result)
+        raise HTTPException(status_code=501, detail=f"Disconnect for {service} not implemented")
     except Exception as e:
         logger.error(f"Error disconnecting from {service}: {e}")
         return APIResponse(success=False, error=str(e))

--- a/backend/routes/keyword_research.py
+++ b/backend/routes/keyword_research.py
@@ -54,41 +54,7 @@ async def research_keywords(
                 error=result.get("error")
             )
         else:
-            # Mock response when agent not available
-            mock_keywords = []
-            for keyword in request.seed_keywords:
-                mock_keywords.append({
-                    "keyword": keyword,
-                    "search_volume": abs(hash(keyword)) % 50000 + 1000,
-                    "difficulty": round((abs(hash(keyword + "diff")) % 100) / 100 * 100, 1),
-                    "cpc": round((abs(hash(keyword + "cpc")) % 500) / 100, 2),
-                    "competition": ["Low", "Medium", "High"][abs(hash(keyword)) % 3],
-                    "serp_features": ["Featured Snippet", "People Also Ask", "Images"],
-                    "trend_data": [
-                        {"month": f"2024-{str(i+1).zfill(2)}", "volume": 100 + (i * 5)} 
-                        for i in range(12)
-                    ]
-                })
-            
-            # Save to database
-            supabase = await get_supabase_client()
-            research_data = {
-                "created_by": user_id,
-                "query": ", ".join(request.seed_keywords),
-                "keywords": mock_keywords
-            }
-            
-            result = supabase.table("keyword_research").insert(research_data).execute()
-            
-            return APIResponse(
-                success=True,
-                data={
-                    "research_id": result.data[0]["id"] if result.data else None,
-                    "keywords": mock_keywords,
-                    "total_keywords": len(mock_keywords),
-                    "query": ", ".join(request.seed_keywords)
-                }
-            )
+            raise HTTPException(status_code=503, detail="Keyword research agent not available")
             
     except Exception as e:
         logger.error(f"Error in keyword research: {e}")
@@ -118,43 +84,7 @@ async def get_competitor_keywords(
                 error=result.get("error")
             )
         else:
-            # Mock competitor keywords
-            domain_name = request.competitor_domain.split('.')[0]
-            mock_keywords = [
-                {
-                    "keyword": f"{domain_name} review",
-                    "search_volume": 15000,
-                    "difficulty": 65.5,
-                    "cpc": 2.50,
-                    "competition": "High",
-                    "serp_features": ["Ads", "Reviews", "Local Pack"],
-                    "trend_data": [
-                        {"month": f"2024-{str(i+1).zfill(2)}", "volume": 95 + (i * 2)} 
-                        for i in range(12)
-                    ]
-                },
-                {
-                    "keyword": f"{domain_name} alternative",
-                    "search_volume": 8500,
-                    "difficulty": 55.2,
-                    "cpc": 3.20,
-                    "competition": "Medium",
-                    "serp_features": ["Featured Snippet", "People Also Ask"],
-                    "trend_data": [
-                        {"month": f"2024-{str(i+1).zfill(2)}", "volume": 90 + (i * 3)} 
-                        for i in range(12)
-                    ]
-                }
-            ]
-            
-            return APIResponse(
-                success=True,
-                data={
-                    "keywords": mock_keywords,
-                    "total_keywords": len(mock_keywords),
-                    "competitor_domain": request.competitor_domain
-                }
-            )
+            raise HTTPException(status_code=503, detail="Keyword research agent not available")
             
     except Exception as e:
         logger.error(f"Error in competitor keyword research: {e}")
@@ -184,43 +114,7 @@ async def get_trending_keywords(
                 error=result.get("error")
             )
         else:
-            # Mock trending keywords
-            industry = request.industry or "marketing"
-            mock_keywords = [
-                {
-                    "keyword": f"AI {industry}",
-                    "search_volume": 45000,
-                    "difficulty": 78.5,
-                    "cpc": 4.50,
-                    "competition": "High",
-                    "serp_features": ["News", "Videos", "Featured Snippet"],
-                    "trend_data": [
-                        {"month": f"2024-{str(i+1).zfill(2)}", "volume": 100 + (i * 8)} 
-                        for i in range(12)
-                    ]
-                },
-                {
-                    "keyword": f"{industry} automation",
-                    "search_volume": 32000,
-                    "difficulty": 62.3,
-                    "cpc": 3.80,
-                    "competition": "Medium",
-                    "serp_features": ["Featured Snippet", "People Also Ask"],
-                    "trend_data": [
-                        {"month": f"2024-{str(i+1).zfill(2)}", "volume": 95 + (i * 6)} 
-                        for i in range(12)
-                    ]
-                }
-            ]
-            
-            return APIResponse(
-                success=True,
-                data={
-                    "keywords": mock_keywords,
-                    "total_keywords": len(mock_keywords),
-                    "industry": industry
-                }
-            )
+            raise HTTPException(status_code=503, detail="Keyword research agent not available")
             
     except Exception as e:
         logger.error(f"Error in trending keyword research: {e}")

--- a/backend/routes/leads.py
+++ b/backend/routes/leads.py
@@ -24,29 +24,7 @@ async def get_leads(token: str = Depends(verify_token)):
             result = await agent_manager.lead_generation_agent.get_leads()
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            mock_leads = [
-                {
-                    "id": str(uuid.uuid4()),
-                    "name": "John Smith",
-                    "email": "john.smith@example.com",
-                    "company": "Tech Corp",
-                    "score": 85,
-                    "status": "qualified",
-                    "source": "website",
-                    "created_at": "2024-01-15T10:00:00Z"
-                },
-                {
-                    "id": str(uuid.uuid4()),
-                    "name": "Sarah Johnson",
-                    "email": "sarah.j@company.com",
-                    "company": "Innovation Inc",
-                    "score": 72,
-                    "status": "contacted",
-                    "source": "social_media",
-                    "created_at": "2024-01-14T14:30:00Z"
-                }
-            ]
-            return APIResponse(success=True, data=mock_leads)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error getting leads: {e}")
         return APIResponse(success=False, error=str(e))
@@ -60,17 +38,7 @@ async def search_leads(q: str, token: str = Depends(verify_token)):
             result = await agent_manager.lead_generation_agent.find_leads(search_criteria)
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            mock_results = [
-                {
-                    "id": str(uuid.uuid4()),
-                    "name": f"Lead matching '{q}'",
-                    "email": f"lead@{q.lower()}.com",
-                    "company": f"{q} Company",
-                    "score": 78,
-                    "status": "new"
-                }
-            ]
-            return APIResponse(success=True, data=mock_results)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error searching leads: {e}")
         return APIResponse(success=False, error=str(e))
@@ -83,17 +51,7 @@ async def get_lead_analytics(token: str = Depends(verify_token)):
             result = await agent_manager.lead_generation_agent.get_lead_analytics()
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            mock_analytics = {
-                "total_leads": 1247,
-                "qualified_leads": 342,
-                "conversion_rate": 27.4,
-                "avg_score": 68.5,
-                "trends": {
-                    "weekly_growth": 12.3,
-                    "monthly_growth": 45.7
-                }
-            }
-            return APIResponse(success=True, data=mock_analytics)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error getting lead analytics: {e}")
         return APIResponse(success=False, error=str(e))
@@ -106,15 +64,7 @@ async def create_lead(lead_data: Dict[str, Any], token: str = Depends(verify_tok
             result = await agent_manager.lead_generation_agent.add_lead(lead_data)
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            from datetime import datetime
-            new_lead = {
-                "id": str(uuid.uuid4()),
-                "score": 50,
-                "status": "new",
-                "created_at": datetime.now().isoformat() + "Z",
-                **lead_data
-            }
-            return APIResponse(success=True, data=new_lead)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error creating lead: {e}")
         return APIResponse(success=False, error=str(e))
@@ -128,28 +78,7 @@ async def export_leads(format: str = "csv", token: str = Depends(verify_token)):
             result = await agent_manager.lead_generation_agent.get_leads()
             leads_data = result.get("data", []) if result["success"] else []
         else:
-            leads_data = [
-                {
-                    "id": str(uuid.uuid4()),
-                    "name": "John Smith",
-                    "email": "john.smith@example.com",
-                    "company": "Tech Corp",
-                    "score": 85,
-                    "status": "qualified",
-                    "source": "website",
-                    "created_at": "2024-01-15T10:00:00Z"
-                },
-                {
-                    "id": str(uuid.uuid4()),
-                    "name": "Sarah Johnson",
-                    "email": "sarah.j@company.com",
-                    "company": "Innovation Inc",
-                    "score": 72,
-                    "status": "contacted",
-                    "source": "social_media",
-                    "created_at": "2024-01-14T14:30:00Z"
-                }
-            ]
+            raise HTTPException(status_code=503, detail="AI agents not available")
 
         if format.lower() == "csv":
             # Create CSV export
@@ -189,7 +118,6 @@ async def sync_leads(token: str = Depends(verify_token)):
     """Sync leads from external sources"""
     try:
         if agent_manager.agents_available:
-            # Simulate sync operation
             result = await agent_manager.lead_generation_agent.get_leads()
             sync_results = {
                 "synced_count": len(result.get("data", [])) if result["success"] else 0,
@@ -200,15 +128,7 @@ async def sync_leads(token: str = Depends(verify_token)):
             }
             return APIResponse(success=True, data=sync_results)
         else:
-            # Mock sync results
-            sync_results = {
-                "synced_count": 25,
-                "new_leads": 8,
-                "updated_leads": 17,
-                "sync_time": datetime.now().isoformat() + "Z",
-                "sources": ["website", "social_media", "email_campaigns", "crm"]
-            }
-            return APIResponse(success=True, data=sync_results)
+            raise HTTPException(status_code=503, detail="AI agents not available")
     except Exception as e:
         logger.error(f"Error syncing leads: {e}")
         return APIResponse(success=False, error=str(e))

--- a/backend/routes/proposals.py
+++ b/backend/routes/proposals.py
@@ -23,31 +23,7 @@ async def generate_proposal(proposal_data: Dict[str, Any], token: str = Depends(
             result = await agent_manager.proposal_generator.generate_proposal(proposal_data)
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            # Mock proposal generation
-            mock_proposal = {
-                "id": str(uuid.uuid4()),
-                "template_type": proposal_data.get("template_type", "custom"),
-                "client_info": proposal_data.get("client_info", {}),
-                "content": {
-                    "executive_summary": "This is a mock proposal generated for demonstration purposes.",
-                    "proposed_services": "Mock services based on your requirements."
-                },
-                "pricing": [
-                    {"item": "Service 1", "description": "Mock service", "price": 5000, "quantity": 1},
-                    {"item": "Service 2", "description": "Another mock service", "price": 3000, "quantity": 1}
-                ],
-                "timeline": [
-                    {"phase": "Planning", "duration": "1 week", "deliverables": ["Project plan"]},
-                    {"phase": "Implementation", "duration": "4 weeks", "deliverables": ["Main deliverables"]}
-                ],
-                "terms": {
-                    "payment_terms": "50% upfront, 50% upon completion",
-                    "warranty": "90-day warranty"
-                },
-                "created_at": datetime.now().isoformat(),
-                "status": "draft"
-            }
-            return APIResponse(success=True, data=mock_proposal)
+            raise HTTPException(status_code=503, detail="Proposal agent not available")
     except Exception as e:
         logger.error(f"Error generating proposal: {e}")
         return APIResponse(success=False, error=str(e))
@@ -63,47 +39,7 @@ async def get_proposal_templates(token: Optional[str] = Depends(verify_token)):
             logger.info(f"Agent templates result: {result}")
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            # Comprehensive mock templates with proper structure
-            mock_templates = {
-                "trade_services": {
-                    "name": "Trade Services Template",
-                    "description": "Professional template for trade services like plumbing, electrical, HVAC, construction, landscaping, etc.",
-                    "sections": ["service_assessment", "project_scope", "materials_labor", "timeline", "pricing", "warranty_terms"],
-                    "default_services": ["Service Assessment", "Installation/Repair", "Quality Inspection", "Cleanup & Completion"],
-                    "category": "trade"
-                },
-                "digital_marketing": {
-                    "name": "Digital Marketing Template",
-                    "description": "Comprehensive template for digital marketing services, SEO, social media campaigns, and advertising",
-                    "sections": ["executive_summary", "marketing_strategy", "proposed_services", "timeline", "investment", "kpis"],
-                    "default_services": ["SEO Optimization", "Content Marketing", "Social Media Management", "PPC Advertising", "Analytics & Reporting"],
-                    "category": "marketing"
-                },
-                "web_development": {
-                    "name": "Web Development Template",
-                    "description": "Complete template for website and web application development projects",
-                    "sections": ["project_overview", "technical_requirements", "development_phases", "timeline", "pricing", "terms"],
-                    "default_services": ["UI/UX Design", "Frontend Development", "Backend Development", "Testing & QA", "Deployment"],
-                    "category": "development"
-                },
-                "consulting": {
-                    "name": "Business Consulting Template",
-                    "description": "Professional template for business strategy, operations, and management consulting services",
-                    "sections": ["executive_summary", "situation_analysis", "recommendations", "implementation", "timeline", "fees"],
-                    "default_services": ["Strategy Consulting", "Process Optimization", "Change Management", "Training & Development"],
-                    "category": "consulting"
-                },
-                "general_business": {
-                    "name": "General Business Template",
-                    "description": "Flexible template suitable for various business services and projects",
-                    "sections": ["overview", "services", "timeline", "pricing", "terms"],
-                    "default_services": ["Business Analysis", "Solution Implementation", "Support & Training"],
-                    "category": "general"
-                }
-            }
-            
-            logger.info(f"Returning mock templates: {list(mock_templates.keys())}")
-            return APIResponse(success=True, data=mock_templates)
+            raise HTTPException(status_code=503, detail="Proposal agent not available")
             
     except Exception as e:
         logger.error(f"Error getting templates: {e}")
@@ -123,25 +59,7 @@ async def get_proposals(status: Optional[str] = None, client: Optional[str] = No
             result = await agent_manager.proposal_generator.get_proposals(filters)
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            mock_proposals = [
-                {
-                    "id": str(uuid.uuid4()),
-                    "client_name": "Acme Corp",
-                    "template_type": "marketing_services",
-                    "status": "sent",
-                    "created_at": "2024-01-15T10:00:00Z",
-                    "value": 15000
-                },
-                {
-                    "id": str(uuid.uuid4()),
-                    "client_name": "TechStart Inc", 
-                    "template_type": "web_development",
-                    "status": "draft",
-                    "created_at": "2024-01-14T14:30:00Z",
-                    "value": 25000
-                }
-            ]
-            return APIResponse(success=True, data=mock_proposals)
+            raise HTTPException(status_code=503, detail="Proposal agent not available")
     except Exception as e:
         logger.error(f"Error getting proposals: {e}")
         return APIResponse(success=False, error=str(e))
@@ -156,12 +74,7 @@ async def save_proposal(proposal_id: str, proposal_data: Dict[str, Any], token: 
             result = await agent_manager.proposal_generator.save_proposal(proposal_data)
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            saved_proposal = {
-                **proposal_data,
-                "id": proposal_id,
-                "saved_at": datetime.now().isoformat()
-            }
-            return APIResponse(success=True, data=saved_proposal)
+            raise HTTPException(status_code=503, detail="Proposal agent not available")
     except Exception as e:
         logger.error(f"Error saving proposal: {e}")
         return APIResponse(success=False, error=str(e))
@@ -176,13 +89,7 @@ async def export_proposal(proposal_id: str, format_data: Dict[str, str], token: 
             result = await agent_manager.proposal_generator.export_proposal(proposal_id, format_type)
             return APIResponse(success=result["success"], data=result.get("data"), error=result.get("error"))
         else:
-            export_data = {
-                "proposal_id": proposal_id,
-                "format": format_type,
-                "download_url": f"/api/proposals/{proposal_id}/download/{format_type}",
-                "generated_at": datetime.now().isoformat()
-            }
-            return APIResponse(success=True, data=export_data)
+            raise HTTPException(status_code=503, detail="Proposal agent not available")
     except Exception as e:
         logger.error(f"Error exporting proposal: {e}")
         return APIResponse(success=False, error=str(e))


### PR DESCRIPTION
## Summary
- implement real brand chat via OpenAI
- drop mock engagement metrics in social agent
- remove placeholder responses in content, email, leads, integrations, proposals, and keyword routes
- fail fast when agents are unavailable

## Testing
- `npx vitest run` *(fails: useNavigate requires Router)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6872146ed3f4832388ee0b00e3389a29