### PR TITLE
Enable automatic onboarding tour

### DIFF
--- a/docs/guides/user-guides/getting-started.md
+++ b/docs/guides/user-guides/getting-started.md
@@ -5,6 +5,8 @@
 
 This guide will help you get started with the platform and set up your first campaigns.
 
+When you first sign in, an onboarding tour automatically begins to walk you through the main areas of the app. You can skip or complete the tour at any time.
+
 ## First Steps
 
 ### 1. Account Setup

--- a/src/contexts/OnboardingContext.tsx
+++ b/src/contexts/OnboardingContext.tsx
@@ -14,6 +14,7 @@ interface OnboardingContextType {
   currentStep: number;
   steps: OnboardingStep[];
   startOnboarding: (steps: OnboardingStep[]) => void;
+  startDefaultOnboarding: () => void;
   nextStep: () => void;
   prevStep: () => void;
   skipOnboarding: () => void;
@@ -69,7 +70,7 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({ children
     setIsActive(false);
   };
 
-  // Removed auto-starting onboarding that was causing overlay issues
+  // Automatically start onboarding on first visit
 
   const startDefaultOnboarding = () => {
     const defaultSteps: OnboardingStep[] = [
@@ -113,11 +114,20 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({ children
     startOnboarding(defaultSteps);
   };
 
+  useEffect(() => {
+    const skipped = localStorage.getItem('onboarding_skipped');
+    const completed = localStorage.getItem('onboarding_completed');
+    if (!skipped && !completed) {
+      startDefaultOnboarding();
+    }
+  }, []);
+
   const value = {
     isActive,
     currentStep,
     steps,
     startOnboarding,
+    startDefaultOnboarding,
     nextStep,
     prevStep,
     skipOnboarding,


### PR DESCRIPTION
## Summary
- start default onboarding if the tour hasn't been skipped or completed
- expose `startDefaultOnboarding` from `OnboardingContext`
- document that new users see an onboarding tour automatically

## Testing
- `npm run lint` *(fails: Unexpected any, no-require-imports)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687384275a08832390eca9029be518dd