### PR TITLE
Add conversation-aware knowledge search

### DIFF
--- a/supabase/functions/chat-ai/index.ts
+++ b/supabase/functions/chat-ai/index.ts
@@ -1,0 +1,167 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL');
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabase = createClient(supabaseUrl!, serviceKey!);
+    const { message, conversationId, context } = await req.json();
+
+    if (!conversationId || !message) {
+      throw new Error('conversationId and message required');
+    }
+
+    const { data: history } = await supabase
+      .from('conversation_messages')
+      .select('role, content')
+      .eq('conversation_id', conversationId)
+      .order('timestamp', { ascending: true })
+      .limit(20);
+
+    let historyText = (history || [])
+      .map((m: any) => `${m.role}: ${m.content}`)
+      .join('\n');
+
+    if (estimateTokenCount(historyText) > 1500) {
+      historyText = await summarizeText(historyText, openAIApiKey!);
+    }
+
+    const embedding = await generateEmbedding(`${historyText}\n${message}`, openAIApiKey!);
+
+    const { data: chunks } = await supabase
+      .rpc('search_knowledge_chunks', {
+        p_user_id: context?.userId,
+        p_query_embedding: embedding,
+        p_limit: 5,
+        p_similarity_threshold: 0.7,
+      });
+
+    const knowledgeContext = chunks && chunks.length
+      ? '\n\nRelevant knowledge:\n' +
+        chunks.map((c: any) => `- ${c.chunk_content}`).join('\n')
+      : '';
+
+    const messages = [
+      { role: 'system', content: `You are a helpful marketing assistant.${knowledgeContext}` },
+      ...(history || []).map((m: any) => ({ role: m.role, content: m.content })),
+      { role: 'user', content: message },
+    ];
+
+    const aiResponse = await callOpenAI(messages, openAIApiKey!);
+
+    const userEmbedding = await generateEmbedding(message, openAIApiKey!);
+    await supabase.from('conversation_messages').insert({
+      conversation_id: conversationId,
+      role: 'user',
+      content: message,
+      embedding: userEmbedding,
+    });
+
+    const assistantEmbedding = await generateEmbedding(aiResponse, openAIApiKey!);
+    await supabase.from('conversation_messages').insert({
+      conversation_id: conversationId,
+      role: 'assistant',
+      content: aiResponse,
+      embedding: assistantEmbedding,
+    });
+
+    if (chunks && chunks.length) {
+      const refs = chunks.map((c: any) => ({
+        conversation_id: conversationId,
+        chunk_id: c.chunk_id,
+      }));
+      await supabase.from('conversation_knowledge_refs').insert(refs);
+    }
+
+    return new Response(
+      JSON.stringify({ response: aiResponse }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (error) {
+    console.error('chat-ai error:', error);
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});
+
+async function callOpenAI(messages: any[], apiKey: string): Promise<string> {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages,
+      temperature: 0.7,
+      max_tokens: 1500,
+    }),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(`OpenAI API error: ${data.error?.message || 'Unknown error'}`);
+  }
+  return data.choices[0].message.content as string;
+}
+
+async function generateEmbedding(text: string, apiKey: string): Promise<number[]> {
+  const response = await fetch('https://api.openai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ input: text, model: 'text-embedding-ada-002' }),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(`OpenAI API error: ${data.error?.message || 'Unknown error'}`);
+  }
+  return data.data[0].embedding as number[];
+}
+
+async function summarizeText(text: string, apiKey: string): Promise<string> {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'Summarize the following text' },
+        { role: 'user', content: text },
+      ],
+      max_tokens: 200,
+      temperature: 0.3,
+    }),
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(`OpenAI API error: ${data.error?.message || 'Unknown error'}`);
+  }
+  return data.choices[0].message.content as string;
+}
+
+function estimateTokenCount(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/supabase/migrations/20250715000000-90234c7d-3390-4a4d-a82c-946eb1c73a8f.sql
+++ b/supabase/migrations/20250715000000-90234c7d-3390-4a4d-a82c-946eb1c73a8f.sql
@@ -1,0 +1,18 @@
+-- Create conversation_knowledge_refs table
+CREATE TABLE public.conversation_knowledge_refs (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  conversation_id UUID NOT NULL REFERENCES public.conversations(id) ON DELETE CASCADE,
+  chunk_id UUID REFERENCES public.knowledge_chunks(id) ON DELETE SET NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.conversation_knowledge_refs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their conversation knowledge refs"
+  ON public.conversation_knowledge_refs
+  FOR ALL
+  USING (auth.uid() = (SELECT user_id FROM public.conversations WHERE id = conversation_id))
+  WITH CHECK (auth.uid() = (SELECT user_id FROM public.conversations WHERE id = conversation_id));
+
+CREATE INDEX IF NOT EXISTS idx_conversation_knowledge_conversation ON public.conversation_knowledge_refs(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_knowledge_chunk ON public.conversation_knowledge_refs(chunk_id);


### PR DESCRIPTION
## Summary
- extend enhanced AI service with conversation search and summarization
- add `chat-ai` Supabase function for knowledge-enhanced chat
- track knowledge chunks with new `conversation_knowledge_refs` table

## Testing
- `npm run lint` *(fails: 542 errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6874460ea9d88323ba395e8047a620dd