### PR TITLE
Fix Render deployment dependency conflicts

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -132,7 +132,7 @@ traitlets==5.14.3
 transformers==4.52.4
 types-python-dateutil==2.9.0.20241206
 typing-inspection==0.4.1
-typing_extensions==4.12.2
+typing_extensions>=4.14.0,<5.0.0
 tzdata==2025.1
 uri-template==1.3.0
 urllib3==2.3.0
@@ -149,6 +149,6 @@ python-dotenv==1.0.1
 fastapi==0.111.0
 uvicorn==0.29.0
 PyJWT==2.8.0
-aiohttp==3.9.5
+aiohttp>=3.12.13,<4.0.0
 supabase==2.9.1
 python-jose[cryptography]==3.3.0


### PR DESCRIPTION
## Summary
- relax the pinned `typing_extensions` requirement to `>=4.14.0,<5.0.0` so libraries like Supabase Realtime can resolve their peer dependencies
- widen the `aiohttp` constraint to `>=3.12.13,<4.0.0` to satisfy the minimum version required by Supabase's realtime client during Render builds

## Testing
- ⚠️ `pip install --dry-run -r backend/requirements.txt` *(cancelled after confirming dependency resolution progressed to the download stage to avoid multi-hundred MB CUDA wheels in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce362543888323a925a8ef0f7c9b8c