### PR TITLE
Add requests dependency for backend deployment

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ aiohttp>=3.9.0,<4.0.0
 
 # Additional utilities
 python-multipart==0.0.20
+requests==2.31.0


### PR DESCRIPTION
## Summary
- add the missing `requests` dependency so the backend auth module loads during deployment

## Testing
- `PYTHONPATH=backend python -m pytest backend/tests` *(fails: Missing SUPABASE_URL or SUPABASE_KEY environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68d38a886abc8323bf8a77b9ee212f64