### PR TITLE
Add psutil dependency for system health route

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ aiohttp>=3.9.0,<4.0.0
 # Additional utilities
 python-multipart==0.0.20
 requests==2.31.0
+psutil==5.9.8


### PR DESCRIPTION
## Summary
- add psutil as a backend dependency so the system health route can import it during startup

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'routes')*

------
https://chatgpt.com/codex/tasks/task_e_68d3920580348323b10aa65a752e513d